### PR TITLE
removed tree-sitter COBOL from the dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,6 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tree-sitter 0.20.10",
- "tree-sitter-COBOL",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
@@ -2583,14 +2582,6 @@ dependencies = [
  "regex",
 ]
 
-[[package]]
-name = "tree-sitter-COBOL"
-version = "0.0.1"
-source = "git+https://github.com/BloopAI/tree-sitter-cobol#8ba6692cc3c2bded0693d198936c6e26e6501230"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
-]
 
 [[package]]
 name = "tree-sitter-c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev 
 tree-sitter-ruby = "0.20.0"
 tree-sitter-r = "0.19.5"
 tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php" }
-tree-sitter-COBOL = { git = "https://github.com/BloopAI/tree-sitter-cobol" }
 petgraph = { version = "0.6.4", default-features = false, features = ["serde-1"] }
 
 # file processing


### PR DESCRIPTION
The tree-sitter COBOL is a broken dependency and results in the following error on Windows:

```
pip failed to build package:
    code-nav-devon

Some possibly relevant errors from pip install:
    warning: tree-sitter-COBOL@0.0.1: Compiler family detection failed due to error: ToolExecError: Command "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.40.33807\\bin\\HostX64\\x64\\cl.exe" "-E" "C:\\Users\\myuser\\AppData\\Local\\Temp\\pip-install-3bemqkjo\\code-nav-devon_210f3ff557814fb6813fb5a48d037cea\\target\\release\\build\\tree-sitter-COBOL-ddd2bf2a20f798aa\\out\\11135311020291847115detect_compiler_family.c" with args C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64\cl.exe did not execute successfully (status code exit code: 2).
```


Ref: [https://github.com/entropy-research/Devon/issues/93](https://github.com/entropy-research/Devon/issues/93)